### PR TITLE
Add decorators for tool annotations

### DIFF
--- a/packages/mcp-server-typespec/tsp-output/typespec-mcp-server-js/index.ts
+++ b/packages/mcp-server-typespec/tsp-output/typespec-mcp-server-js/index.ts
@@ -32,6 +32,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "init",
@@ -42,6 +48,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "compile",
@@ -52,6 +64,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "build",
@@ -62,6 +80,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         }
       ],
     };

--- a/packages/typespec-mcp-server-js/src/components/ListToolsHandler.tsx
+++ b/packages/typespec-mcp-server-js/src/components/ListToolsHandler.tsx
@@ -45,5 +45,6 @@ function operationToToolDescriptor(tool: ToolDescriptor) {
         />
       </>
     ),
+    annotations: tool.annotations,
   };
 }

--- a/packages/typespec-mcp/generated-defs/MCP.ts
+++ b/packages/typespec-mcp/generated-defs/MCP.ts
@@ -1,4 +1,4 @@
-import type { DecoratorContext, Interface, Namespace, Operation } from "@typespec/compiler";
+import type { DecoratorContext, Interface, Namespace, Operation, Type } from "@typespec/compiler";
 
 export interface McpServerOptions {
   readonly name?: string;
@@ -8,8 +8,38 @@ export interface McpServerOptions {
 
 /**
  * Declare an operation that is an MCP Tool.
+ *
+ * @param value Default is true.
  */
 export type ToolDecorator = (context: DecoratorContext, target: Operation) => void;
+
+/**
+ * Tool does not modify its environment.
+ *
+ * @param value Default is true.
+ */
+export type ReadonlyDecorator = (context: DecoratorContext, target: Operation, value?: Type) => void;
+
+/**
+ * Tool will not perform any destructive operations.
+ *
+ * @param value Default is true.
+ */
+export type NondestructiveDecorator = (context: DecoratorContext, target: Operation, value?: Type) => void;
+
+/**
+ * Repeated calls with same args have no additional effect
+ *
+ * @param value Default is true.
+ */
+export type IdempotentDecorator = (context: DecoratorContext, target: Operation, value?: Type) => void;
+
+/**
+ * Tool will not interacts with external entities
+ *
+ * @param value Default is true.
+ */
+export type ClosedWorldDecorator = (context: DecoratorContext, target: Operation, value?: Type) => void;
 
 /**
  * Declare a namespace or interface as an MCP Server and provide server
@@ -23,5 +53,9 @@ export type McpServerDecorator = (
 
 export type MCPDecorators = {
   tool: ToolDecorator;
+  readonly: ReadonlyDecorator;
+  nondestructive: NondestructiveDecorator;
+  idempotent: IdempotentDecorator;
+  closedWorld: ClosedWorldDecorator;
   mcpServer: McpServerDecorator;
 };

--- a/packages/typespec-mcp/lib/main.tsp
+++ b/packages/typespec-mcp/lib/main.tsp
@@ -4,8 +4,32 @@ namespace MCP;
 
 /**
  * Declare an operation that is an MCP Tool.
+ * @param value - Default is true.
  */
 extern dec tool(target: Reflection.Operation);
+
+/**
+ * Tool does not modify its environment.
+ * @param value - Default is true.
+ */
+extern dec readonly(target: Reflection.Operation, value?: boolean);
+
+/**
+ * Tool will not perform any destructive operations.
+ * @param value - Default is true.
+ */
+extern dec nondestructive(target: Reflection.Operation, value?: boolean);
+/**
+ * Repeated calls with same args have no additional effect
+ * @param value - Default is true.
+ */
+extern dec idempotent(target: Reflection.Operation, value?: boolean);
+
+/**
+ * Tool will not interacts with external entities
+ * @param value - Default is true.
+ */
+extern dec closedWorld(target: Reflection.Operation, value?: boolean);
 
 model McpServerOptions {
   name?: string;

--- a/packages/typespec-mcp/src/lib.ts
+++ b/packages/typespec-mcp/src/lib.ts
@@ -5,6 +5,10 @@ export const $lib = createTypeSpecLibrary({
   diagnostics: {},
   state: {
     tool: { description: "An MCP tool" },
+    readonly: { description: "Readonly tool" },
+    nondestructive: { description: "Non destructive tool" },
+    idempotent: { description: "Idempotent tool" },
+    closedWorld: { description: "Closed world tool" },
     serializeAsText: {
       description: "Holds the type which is serialized to text",
     },

--- a/packages/typespec-mcp/src/tsp-index.ts
+++ b/packages/typespec-mcp/src/tsp-index.ts
@@ -1,12 +1,24 @@
 import { MCPDecorators } from "../generated-defs/MCP.js";
 import { MCPPrivateDecorators } from "../generated-defs/MCP.Private.js";
-import { $mcpServer, $serializeAsText, $tool } from "./decorators.js";
+import {
+  $mcpServer,
+  $serializeAsText,
+  closedWorldDecorator,
+  idempotentDecorator,
+  nondestructiveDecorator,
+  readonlyDecorator,
+  toolDecorator,
+} from "./decorators.js";
 
 /** @internal */
 export const $decorators = {
   "MCP": {
     mcpServer: $mcpServer,
-    tool: $tool,
+    tool: toolDecorator,
+    readonly: readonlyDecorator,
+    nondestructive: nondestructiveDecorator,
+    idempotent: idempotentDecorator,
+    closedWorld: closedWorldDecorator,
   } satisfies MCPDecorators,
   "MCP.Private": {
     serializeAsText: $serializeAsText,

--- a/samples/http-mcp-bridge/tsp-output/server/index.ts
+++ b/samples/http-mcp-bridge/tsp-output/server/index.ts
@@ -33,6 +33,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "test",
@@ -43,6 +49,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_list",
@@ -53,6 +65,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_create",
@@ -63,6 +81,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_list_public",
@@ -73,6 +97,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_list_starred",
@@ -83,6 +113,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_get",
@@ -93,6 +129,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_update",
@@ -103,6 +145,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_delete",
@@ -113,6 +161,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_list_commits",
@@ -123,6 +177,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_list_forks",
@@ -133,6 +193,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_fork",
@@ -143,6 +209,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_star",
@@ -153,6 +225,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_unstar",
@@ -163,6 +241,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "gists_is_starred",
@@ -173,6 +257,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         }
       ],
     };

--- a/samples/vector/tsp-output/typespec-mcp-server-js/index.ts
+++ b/samples/vector/tsp-output/typespec-mcp-server-js/index.ts
@@ -32,6 +32,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "math_sub_vector",
@@ -42,6 +48,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "math_cross_product",
@@ -52,6 +64,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         },
         {
           name: "math_dot_product",
@@ -62,6 +80,12 @@ server.setRequestHandler(
               $refStrategy: "none",
             }
           ),
+          annotations: {
+            readonlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
         }
       ],
     };


### PR DESCRIPTION
Add decorators for all tool annotations and use of `@summary` for title
```tsp
@readonly
@nondestructive
@idempotent
@closedWorld
@tool  op foo(): void;
```
